### PR TITLE
Updated the URL.

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,4 +1,4 @@
 require 'scraperwiki'
 require File.dirname(__FILE__) + '/lib_icon_rest_xml/scraper'
 
-scrape_icon_rest_xml("http://epb.swan.wa.gov.au/Pages/XC.Track/SearchApplication.aspx", "d=thisweek&k=LodgementDate&t=282,281,283&o=xml")
+scrape_icon_rest_xml("https://elodge.swan.wa.gov.au/Pages/XC.Track/SearchApplication.aspx", "d=thisweek&k=LodgementDate&t=282,281,283&o=xml")


### PR DESCRIPTION
The previous URL (http://epb.swan.wa.gov.au/Pages/XC.Track/SearchApplication.aspx) was resulting in a 404 error.  The URL has changed since this scraper was created.  The new URL is https://elodge.swan.wa.gov.au/Pages/XC.Track/SearchApplication.aspx.  See https://morph.io/planningalerts-scrapers/city_of_swan_develepment_applications.